### PR TITLE
libtorrent 2.0.2

### DIFF
--- a/.github/workflows/docker-buildx.yml
+++ b/.github/workflows/docker-buildx.yml
@@ -11,7 +11,7 @@ on:
 env:
   DOCKERHUB_USER: wiserain
   DOCKERHUB_REPO: libtorrent
-  LIBTORRENT_VER: "2.0.1"
+  LIBTORRENT_VER: "2.0.2"
 
 jobs:
   alpine310:

--- a/alpine3.10/Dockerfile
+++ b/alpine3.10/Dockerfile
@@ -14,7 +14,7 @@ RUN \
 
 RUN \
     echo "**** clone source ****" && \
-    git clone --recurse-submodules https://github.com/arvidn/libtorrent.git /tmp/libtorrent -b "v${LIBTORRENT_VER}" --depth 1
+    GIT_SSL_NO_VERIFY=0 git clone --recurse-submodules https://github.com/arvidn/libtorrent.git /tmp/libtorrent -b "v${LIBTORRENT_VER}" --depth 1
 
 RUN \
     echo "**** build libtorrent-rasterbar ****" && \

--- a/alpine3.10/Dockerfile
+++ b/alpine3.10/Dockerfile
@@ -39,9 +39,9 @@ RUN \
     PY_VER=$(python${PY_MAJOR_VER} -c 'import sys; print(".".join([str(x) for x in sys.version_info[:2]]))') && \
     if [ ${PY_MAJOR_VER} = "3" ]; then \
         ABIFLAGS=$(python${PY_MAJOR_VER} -c 'import sys; print(sys.abiflags)'); \
-        BOOST_PYTHON_NAME="libboost_python38"; \
+        BOOST_PYTHON_NAME="libboost_python37"; \
     else \
-        BOOST_PYTHON_NAME="libboost_python"; \
+        BOOST_PYTHON_NAME="libboost_python-py27"; \
     fi && \
     if [ ! -f "/usr/lib/${BOOST_PYTHON_NAME}.so" ]; then \
         ln -s /usr/lib/libboost_python${PY_VER//./}.so "/usr/lib/${BOOST_PYTHON_NAME}.so"; \

--- a/alpine3.11/Dockerfile
+++ b/alpine3.11/Dockerfile
@@ -14,7 +14,7 @@ RUN \
 
 RUN \
     echo "**** clone source ****" && \
-    git clone --recurse-submodules https://github.com/arvidn/libtorrent.git /tmp/libtorrent -b "v${LIBTORRENT_VER}" --depth 1
+    GIT_SSL_NO_VERIFY=0 git clone --recurse-submodules https://github.com/arvidn/libtorrent.git /tmp/libtorrent -b "v${LIBTORRENT_VER}" --depth 1
 
 RUN \
     echo "**** build libtorrent-rasterbar ****" && \

--- a/alpine3.11/Dockerfile
+++ b/alpine3.11/Dockerfile
@@ -41,7 +41,7 @@ RUN \
         ABIFLAGS=$(python${PY_MAJOR_VER} -c 'import sys; print(sys.abiflags)'); \
         BOOST_PYTHON_NAME="libboost_python38"; \
     else \
-        BOOST_PYTHON_NAME="libboost_python"; \
+        BOOST_PYTHON_NAME="libboost_python-py27"; \
     fi && \
     if [ ! -f "/usr/lib/${BOOST_PYTHON_NAME}.so" ]; then \
         ln -s /usr/lib/libboost_python${PY_VER//./}.so "/usr/lib/${BOOST_PYTHON_NAME}.so"; \

--- a/alpine3.12/Dockerfile
+++ b/alpine3.12/Dockerfile
@@ -16,7 +16,7 @@ RUN \
 
 RUN \
     echo "**** clone source ****" && \
-    git clone --recurse-submodules https://github.com/arvidn/libtorrent.git /tmp/libtorrent -b "v${LIBTORRENT_VER}" --depth 1
+    GIT_SSL_NO_VERIFY=0 git clone --recurse-submodules https://github.com/arvidn/libtorrent.git /tmp/libtorrent -b "v${LIBTORRENT_VER}" --depth 1
 
 RUN \
     echo "**** build libtorrent ****" && \

--- a/ubuntu20.04/Dockerfile
+++ b/ubuntu20.04/Dockerfile
@@ -19,7 +19,7 @@ RUN \
         `# python-deps` \
         python3-setuptools python3-all-dev
 
-ENV CMAKE_VER="3.19.0"
+ENV CMAKE_VER="3.19.2"
 RUN \
     echo "**** install cmake v${CMAKE_VER} ****" && \
     apt-get update && \
@@ -44,7 +44,7 @@ RUN \
 
 RUN \
     echo "**** clone source ****" && \
-    git clone --recurse-submodules https://github.com/arvidn/libtorrent.git /tmp/libtorrent -b "v${LIBTORRENT_VER}" --depth 1
+    GIT_SSL_NO_VERIFY=0 git clone --recurse-submodules https://github.com/arvidn/libtorrent.git /tmp/libtorrent -b "v${LIBTORRENT_VER}" --depth 1
 
 RUN \
     echo "**** build libtorrent ****" && \

--- a/ubuntu20.10/Dockerfile
+++ b/ubuntu20.10/Dockerfile
@@ -19,7 +19,7 @@ RUN \
         `# python-deps` \
         python3-setuptools python3-all-dev
 
-ENV CMAKE_VER="3.19.0"
+ENV CMAKE_VER="3.19.2"
 RUN \
     echo "**** install cmake v${CMAKE_VER} ****" && \
     apt-get update && \
@@ -44,7 +44,7 @@ RUN \
 
 RUN \
     echo "**** clone source ****" && \
-    git clone --recurse-submodules https://github.com/arvidn/libtorrent.git /tmp/libtorrent -b "v${LIBTORRENT_VER}" --depth 1
+    GIT_SSL_NO_VERIFY=0 git clone --recurse-submodules https://github.com/arvidn/libtorrent.git /tmp/libtorrent -b "v${LIBTORRENT_VER}" --depth 1
 
 RUN \
     echo "**** build libtorrent ****" && \


### PR DESCRIPTION
- bump version to 2.0.2
- bump cmake to 3.19.2 for ubuntu builds
- no verify ssl for git clone (keep throwing error on verification)