### PR TITLE
v1: Cross build Alpine arm64

### DIFF
--- a/.github/workflows/buildx.yml
+++ b/.github/workflows/buildx.yml
@@ -21,7 +21,6 @@ jobs:
     strategy:
       matrix:
         distro: [alpine3.20, alpine3.21, alpine3.22, alpine3.23]
-        arch: [amd64, arm64]
     steps:
       -
         name: Checkout
@@ -40,16 +39,22 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       -
+        name: Cross Build and Load Artifacts
+        run: |
+          cd ${{ matrix.distro }}
+          docker build --build-arg LT_VER=${{ env.LT_VER }} -t lt-build:local -f cross-build.dockerfile .
+          docker run --rm -v ${PWD}/build:/build lt-build:local /bin/sh -c "rm -rf /build/* && mv /lt-build/* /build/"
+      -
         name: Buildx and Push
         uses: docker/build-push-action@v7
         with:
           context: ${{ matrix.distro }}/.
           file: ${{ matrix.distro }}/Dockerfile
           tags: |
-            ${{ env.IMAGE_NAME }}:${{ env.LT_VER }}-${{ matrix.distro }}-${{ matrix.arch }}
-            ${{ env.IMAGE_NAME }}:${{ env.LT_VER_MINOR }}-${{ matrix.distro }}-${{ matrix.arch }}
-            ${{ env.IMAGE_NAME }}:${{ env.LT_VER_MAJOR }}-${{ matrix.distro }}-${{ matrix.arch }}
-          platforms: linux/${{ matrix.arch }}
+            ${{ env.IMAGE_NAME }}:${{ env.LT_VER }}-${{ matrix.distro }}
+            ${{ env.IMAGE_NAME }}:${{ env.LT_VER_MINOR }}-${{ matrix.distro }}
+            ${{ env.IMAGE_NAME }}:${{ env.LT_VER_MAJOR }}-${{ matrix.distro }}
+          platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
             LT_VER=${{ env.LT_VER }}
@@ -62,51 +67,9 @@ jobs:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
           status: ${{ job.status }}
           description: |
-            ${{ env.IMAGE_NAME }}:${{ env.LT_VER }}-${{ matrix.distro }}-${{ matrix.arch }}
-            ${{ env.IMAGE_NAME }}:${{ env.LT_VER_MINOR }}-${{ matrix.distro }}-${{ matrix.arch }}
-            ${{ env.IMAGE_NAME }}:${{ env.LT_VER_MAJOR }}-${{ matrix.distro }}-${{ matrix.arch }}
-
-  alpine-release:
-    needs:
-      - alpine
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-    strategy:
-      matrix:
-        distro: [alpine3.20, alpine3.21, alpine3.22, alpine3.23]
-    steps:
-      -
-        name: Set up Buildx
-        uses: docker/setup-buildx-action@v4
-      -
-        name: Login to ghcr.io
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - 
-        name: Create manifest and push for ${{ env.LT_VER }}-${{ matrix.distro }}
-        run: |
-          docker manifest create ${{ env.IMAGE_NAME }}:${{ env.LT_VER }}-${{ matrix.distro }} \
-            ${{ env.IMAGE_NAME }}:${{ env.LT_VER }}-${{ matrix.distro }}-amd64 \
-            ${{ env.IMAGE_NAME }}:${{ env.LT_VER }}-${{ matrix.distro }}-arm64
-          docker manifest push ${{ env.IMAGE_NAME }}:${{ env.LT_VER }}-${{ matrix.distro }}
-      - 
-        name: Create manifest and push for ${{ env.LT_VER_MINOR }}-${{ matrix.distro }}
-        run: |
-          docker manifest create ${{ env.IMAGE_NAME }}:${{ env.LT_VER_MINOR }}-${{ matrix.distro }} \
-            ${{ env.IMAGE_NAME }}:${{ env.LT_VER_MINOR }}-${{ matrix.distro }}-amd64 \
-            ${{ env.IMAGE_NAME }}:${{ env.LT_VER_MINOR }}-${{ matrix.distro }}-arm64
-          docker manifest push ${{ env.IMAGE_NAME }}:${{ env.LT_VER_MINOR }}-${{ matrix.distro }}
-      - 
-        name: Create manifest and push for ${{ env.LT_VER_MAJOR }}-${{ matrix.distro }}
-        run: |
-          docker manifest create ${{ env.IMAGE_NAME }}:${{ env.LT_VER_MAJOR }}-${{ matrix.distro }} \
-            ${{ env.IMAGE_NAME }}:${{ env.LT_VER_MAJOR }}-${{ matrix.distro }}-amd64 \
-            ${{ env.IMAGE_NAME }}:${{ env.LT_VER_MAJOR }}-${{ matrix.distro }}-arm64
-          docker manifest push ${{ env.IMAGE_NAME }}:${{ env.LT_VER_MAJOR }}-${{ matrix.distro }}
+            ${{ env.IMAGE_NAME }}:${{ env.LT_VER }}-${{ matrix.distro }}
+            ${{ env.IMAGE_NAME }}:${{ env.LT_VER_MINOR }}-${{ matrix.distro }}
+            ${{ env.IMAGE_NAME }}:${{ env.LT_VER_MAJOR }}-${{ matrix.distro }}
 
   ubuntu:
     runs-on: ubuntu-latest
@@ -167,7 +130,7 @@ jobs:
 
   make-release:
     needs:
-      - alpine-release
+      - alpine
       - ubuntu
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/buildx_on_pr.yml
+++ b/.github/workflows/buildx_on_pr.yml
@@ -40,7 +40,6 @@ jobs:
     strategy:
       matrix:
         distro: ${{ fromJSON(needs.changes.outputs.alpine) }}
-        arch: [amd64, arm64]
     steps:
       -
         name: Checkout
@@ -58,6 +57,12 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Cross Build and Load Artifacts
+        run: |
+          cd ${{ matrix.distro }}
+          docker build --build-arg LT_VER=${{ env.LT_VER }} -t lt-build:local -f cross-build.dockerfile .
+          docker run --rm -v ${PWD}/build:/build lt-build:local /bin/sh -c "rm -rf /build/* && mv /lt-build/* /build/"
       -
         name: Buildx and Push
         uses: docker/build-push-action@v7
@@ -65,49 +70,12 @@ jobs:
           context: ${{ matrix.distro }}/.
           file: ${{ matrix.distro }}/Dockerfile
           tags: |
-            ${{ env.IMAGE_NAME }}:testing-${{ matrix.distro }}-${{ matrix.arch }}
-          platforms: linux/${{ matrix.arch }}
+            ${{ env.IMAGE_NAME }}:testing-${{ matrix.distro }}
+          platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
             LT_VER=${{ env.LT_VER }}
           provenance: false
-
-
-  alpine-release:
-    needs:
-      - changes
-      - alpine
-    if: ${{ needs.changes.outputs.alpine != '[]' && needs.changes.outputs.alpine != '' }}
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-    strategy:
-      matrix:
-        distro: ${{ fromJSON(needs.changes.outputs.alpine) }}
-    steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v6
-      -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-      -
-        name: Set up Buildx
-        uses: docker/setup-buildx-action@v4
-      -
-        name: Login to ghcr.io
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - 
-        name: Create manifest and push for testing
-        run: |
-          docker manifest create ${{ env.IMAGE_NAME }}:testing-${{ matrix.distro }} \
-            ${{ env.IMAGE_NAME }}:testing-${{ matrix.distro }}-amd64 \
-            ${{ env.IMAGE_NAME }}:testing-${{ matrix.distro }}-arm64
-          docker manifest push ${{ env.IMAGE_NAME }}:testing-${{ matrix.distro }}
       -
         name: Generate Release Assets
         run: |

--- a/alpine3.20/Dockerfile
+++ b/alpine3.20/Dockerfile
@@ -1,55 +1,15 @@
 FROM alpine:3.20 AS alpine
 
 # 
-# BUILD
-# 
-FROM alpine AS build-base
-
-ARG LT_VER
-
-RUN \
-    echo "**** install build-deps ****" && \
-    apk add --no-cache --update \
-        build-base \
-        `# including file fortify-headers g++ gcc libc-dev make` \
-        openssl-dev \
-        boost-dev \
-        git \
-        cmake \
-        `# python-deps` \
-        boost-python3 py3-setuptools python3-dev
-
-RUN \
-    echo "**** clone source ****" && \
-    GIT_SSL_NO_VERIFY=0 git clone https://github.com/arvidn/libtorrent.git /tmp/libtorrent -b "v${LT_VER}" --depth 1
-
-RUN \
-    echo "**** build libtorrent ****" && \
-    PYTHON_VERSION=$(python3 -c 'import sys; print(".".join(map(str,sys.version_info[:2])))') && \
-    mkdir /tmp/libtorrent/_build -p && \
-    cd /tmp/libtorrent/_build && \
-    cmake \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_INSTALL_PREFIX="/usr" \
-        -DCMAKE_INSTALL_LIBDIR="lib" \
-        -Dpython-bindings=ON \
-        -Dboost-python-module-name="python${PYTHON_VERSION//./}" \
-        "../" && \
-    make VERBOSE=1 -j$(nproc) && \
-    echo "**** install libtorrent ****" && \
-    cd /tmp/libtorrent && \
-    make -C "_build" DESTDIR=/libtorrent-build install && \
-    rm -rf /libtorrent-build/usr/lib/cmake
-
-# 
 # TEST
 # 
 FROM alpine AS test
 
 ARG LT_VER
+ARG TARGETARCH
 
-COPY --from=build-base /libtorrent-build/usr/lib/ /usr/lib/
-COPY --from=build-base /libtorrent-build/usr/lib/ /libtorrent-build/usr/lib/
+COPY build/${TARGETARCH}/usr/ /usr/
+COPY build/${TARGETARCH}/usr/ /libtorrent-build/usr/
 
 RUN \
     echo "**** install runtime packages ****" && \

--- a/alpine3.20/cross-build.dockerfile
+++ b/alpine3.20/cross-build.dockerfile
@@ -1,0 +1,108 @@
+FROM alpine:3.20 AS alpine
+
+#
+# BUILD
+#
+FROM alpine AS build-base
+
+ARG LT_VER
+
+ENV GIT_SSL_NO_VERIFY=0
+
+RUN \
+    echo "**** install build-deps ****" && \
+    apk add --no-cache --update \
+        build-base \
+        openssl-dev \
+        boost-dev \
+        git \
+        cmake \
+        boost-python3 py3-setuptools python3-dev \
+        clang lld apk-tools
+
+RUN \
+    echo "**** clone source ****" && \
+    git clone https://github.com/arvidn/libtorrent.git /tmp/libtorrent -b "v${LT_VER}" --depth 1
+
+#
+# CROSS COMPILE
+#
+FROM build-base AS build-amd64
+
+RUN \
+    echo "**** build libtorrent for amd64 ****" && \
+    PYTHON_VERSION=$(python3 -c 'import sys; print(".".join(map(str,sys.version_info[:2])))') && \
+    mkdir -p /tmp/libtorrent/_build-amd64 && \
+    cd /tmp/libtorrent/_build-amd64 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX="/usr" \
+        -DCMAKE_INSTALL_LIBDIR="lib" \
+        -Dpython-bindings=ON \
+        -Dboost-python-module-name="python${PYTHON_VERSION//./}" \
+        "../" && \
+    make -j$(nproc) && \
+    echo "**** install libtorrent for amd64 ****" && \
+    make DESTDIR=/libtorrent-build install && \
+    rm -rf /libtorrent-build/usr/lib/cmake
+
+FROM build-base AS build-arm64
+
+RUN \
+    echo "**** install arm64 sysroot ****" && \
+    mkdir -p /sysroot/etc/apk && \
+    cp /etc/apk/repositories /sysroot/etc/apk/repositories && \
+    apk --root /sysroot --arch aarch64 --allow-untrusted --initdb add --no-cache \
+        gcc g++ \
+        musl-dev \
+        openssl-dev \
+        boost-dev \
+        boost-python3 \
+        python3-dev \
+        libstdc++ && \
+    echo "**** write cmake toolchain ****" && \
+    { \
+        echo "set(CMAKE_SYSTEM_NAME Linux)"; \
+        echo "set(CMAKE_SYSTEM_PROCESSOR aarch64)"; \
+        echo "set(CMAKE_SYSROOT /sysroot)"; \
+        echo "set(CMAKE_C_COMPILER clang)"; \
+        echo "set(CMAKE_CXX_COMPILER clang++)"; \
+        echo "set(CMAKE_C_COMPILER_TARGET aarch64-alpine-linux-musl)"; \
+        echo "set(CMAKE_CXX_COMPILER_TARGET aarch64-alpine-linux-musl)"; \
+        echo "set(CMAKE_EXE_LINKER_FLAGS_INIT \"-fuse-ld=lld\")"; \
+        echo "set(CMAKE_SHARED_LINKER_FLAGS_INIT \"-fuse-ld=lld\")"; \
+        echo "set(CMAKE_MODULE_LINKER_FLAGS_INIT \"-fuse-ld=lld\")"; \
+        echo "set(CMAKE_FIND_ROOT_PATH /sysroot)"; \
+        echo "set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)"; \
+        echo "set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)"; \
+        echo "set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)"; \
+        echo "set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)"; \
+    } > /tmp/aarch64-alpine-linux-musl.cmake
+
+RUN \
+    echo "**** build libtorrent for arm64 ****" && \
+    PYTHON_VERSION=$(python3 -c 'import sys; print(".".join(map(str,sys.version_info[:2])))') && \
+    mkdir -p /tmp/libtorrent/_build-arm64 && \
+    cd /tmp/libtorrent/_build-arm64 && \
+    cmake \
+        -DCMAKE_TOOLCHAIN_FILE=/tmp/aarch64-alpine-linux-musl.cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX="/usr" \
+        -DCMAKE_INSTALL_LIBDIR="lib" \
+        -Dpython-bindings=ON \
+        -Dboost-python-module-name="python${PYTHON_VERSION//./}" \
+        -DPython3_EXECUTABLE=/usr/bin/python3 \
+        -DPython3_INCLUDE_DIR=/sysroot/usr/include/python${PYTHON_VERSION} \
+        -DPython3_LIBRARY=/sysroot/usr/lib/libpython${PYTHON_VERSION}.so \
+        "../" && \
+    make -j$(nproc) && \
+    echo "**** install libtorrent for arm64 ****" && \
+    make DESTDIR=/libtorrent-build install && \
+    rm -rf /libtorrent-build/usr/lib/cmake
+
+#
+# RELEASE
+#
+FROM alpine
+COPY --from=build-amd64 /libtorrent-build/ /lt-build/amd64/
+COPY --from=build-arm64 /libtorrent-build/ /lt-build/arm64/

--- a/alpine3.21/Dockerfile
+++ b/alpine3.21/Dockerfile
@@ -1,55 +1,15 @@
 FROM alpine:3.21 AS alpine
 
 # 
-# BUILD
-# 
-FROM alpine AS build-base
-
-ARG LT_VER
-
-RUN \
-    echo "**** install build-deps ****" && \
-    apk add --no-cache --update \
-        build-base \
-        `# including file fortify-headers g++ gcc libc-dev make` \
-        openssl-dev \
-        boost-dev \
-        git \
-        cmake \
-        `# python-deps` \
-        boost-python3 py3-setuptools python3-dev
-
-RUN \
-    echo "**** clone source ****" && \
-    GIT_SSL_NO_VERIFY=0 git clone https://github.com/arvidn/libtorrent.git /tmp/libtorrent -b "v${LT_VER}" --depth 1
-
-RUN \
-    echo "**** build libtorrent ****" && \
-    PYTHON_VERSION=$(python3 -c 'import sys; print(".".join(map(str,sys.version_info[:2])))') && \
-    mkdir /tmp/libtorrent/_build -p && \
-    cd /tmp/libtorrent/_build && \
-    cmake \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_INSTALL_PREFIX="/usr" \
-        -DCMAKE_INSTALL_LIBDIR="lib" \
-        -Dpython-bindings=ON \
-        -Dboost-python-module-name="python${PYTHON_VERSION//./}" \
-        "../" && \
-    make VERBOSE=1 -j$(nproc) && \
-    echo "**** install libtorrent ****" && \
-    cd /tmp/libtorrent && \
-    make -C "_build" DESTDIR=/libtorrent-build install && \
-    rm -rf /libtorrent-build/usr/lib/cmake
-
-# 
 # TEST
 # 
 FROM alpine AS test
 
 ARG LT_VER
+ARG TARGETARCH
 
-COPY --from=build-base /libtorrent-build/usr/lib/ /usr/lib/
-COPY --from=build-base /libtorrent-build/usr/lib/ /libtorrent-build/usr/lib/
+COPY build/${TARGETARCH}/usr/ /usr/
+COPY build/${TARGETARCH}/usr/ /libtorrent-build/usr/
 
 RUN \
     echo "**** install runtime packages ****" && \

--- a/alpine3.21/cross-build.dockerfile
+++ b/alpine3.21/cross-build.dockerfile
@@ -1,0 +1,108 @@
+FROM alpine:3.21 AS alpine
+
+#
+# BUILD
+#
+FROM alpine AS build-base
+
+ARG LT_VER
+
+ENV GIT_SSL_NO_VERIFY=0
+
+RUN \
+    echo "**** install build-deps ****" && \
+    apk add --no-cache --update \
+        build-base \
+        openssl-dev \
+        boost-dev \
+        git \
+        cmake \
+        boost-python3 py3-setuptools python3-dev \
+        clang lld apk-tools
+
+RUN \
+    echo "**** clone source ****" && \
+    git clone https://github.com/arvidn/libtorrent.git /tmp/libtorrent -b "v${LT_VER}" --depth 1
+
+#
+# CROSS COMPILE
+#
+FROM build-base AS build-amd64
+
+RUN \
+    echo "**** build libtorrent for amd64 ****" && \
+    PYTHON_VERSION=$(python3 -c 'import sys; print(".".join(map(str,sys.version_info[:2])))') && \
+    mkdir -p /tmp/libtorrent/_build-amd64 && \
+    cd /tmp/libtorrent/_build-amd64 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX="/usr" \
+        -DCMAKE_INSTALL_LIBDIR="lib" \
+        -Dpython-bindings=ON \
+        -Dboost-python-module-name="python${PYTHON_VERSION//./}" \
+        "../" && \
+    make -j$(nproc) && \
+    echo "**** install libtorrent for amd64 ****" && \
+    make DESTDIR=/libtorrent-build install && \
+    rm -rf /libtorrent-build/usr/lib/cmake
+
+FROM build-base AS build-arm64
+
+RUN \
+    echo "**** install arm64 sysroot ****" && \
+    mkdir -p /sysroot/etc/apk && \
+    cp /etc/apk/repositories /sysroot/etc/apk/repositories && \
+    apk --root /sysroot --arch aarch64 --allow-untrusted --initdb add --no-cache \
+        gcc g++ \
+        musl-dev \
+        openssl-dev \
+        boost-dev \
+        boost-python3 \
+        python3-dev \
+        libstdc++ && \
+    echo "**** write cmake toolchain ****" && \
+    { \
+        echo "set(CMAKE_SYSTEM_NAME Linux)"; \
+        echo "set(CMAKE_SYSTEM_PROCESSOR aarch64)"; \
+        echo "set(CMAKE_SYSROOT /sysroot)"; \
+        echo "set(CMAKE_C_COMPILER clang)"; \
+        echo "set(CMAKE_CXX_COMPILER clang++)"; \
+        echo "set(CMAKE_C_COMPILER_TARGET aarch64-alpine-linux-musl)"; \
+        echo "set(CMAKE_CXX_COMPILER_TARGET aarch64-alpine-linux-musl)"; \
+        echo "set(CMAKE_EXE_LINKER_FLAGS_INIT \"-fuse-ld=lld\")"; \
+        echo "set(CMAKE_SHARED_LINKER_FLAGS_INIT \"-fuse-ld=lld\")"; \
+        echo "set(CMAKE_MODULE_LINKER_FLAGS_INIT \"-fuse-ld=lld\")"; \
+        echo "set(CMAKE_FIND_ROOT_PATH /sysroot)"; \
+        echo "set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)"; \
+        echo "set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)"; \
+        echo "set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)"; \
+        echo "set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)"; \
+    } > /tmp/aarch64-alpine-linux-musl.cmake
+
+RUN \
+    echo "**** build libtorrent for arm64 ****" && \
+    PYTHON_VERSION=$(python3 -c 'import sys; print(".".join(map(str,sys.version_info[:2])))') && \
+    mkdir -p /tmp/libtorrent/_build-arm64 && \
+    cd /tmp/libtorrent/_build-arm64 && \
+    cmake \
+        -DCMAKE_TOOLCHAIN_FILE=/tmp/aarch64-alpine-linux-musl.cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX="/usr" \
+        -DCMAKE_INSTALL_LIBDIR="lib" \
+        -Dpython-bindings=ON \
+        -Dboost-python-module-name="python${PYTHON_VERSION//./}" \
+        -DPython3_EXECUTABLE=/usr/bin/python3 \
+        -DPython3_INCLUDE_DIR=/sysroot/usr/include/python${PYTHON_VERSION} \
+        -DPython3_LIBRARY=/sysroot/usr/lib/libpython${PYTHON_VERSION}.so \
+        "../" && \
+    make -j$(nproc) && \
+    echo "**** install libtorrent for arm64 ****" && \
+    make DESTDIR=/libtorrent-build install && \
+    rm -rf /libtorrent-build/usr/lib/cmake
+
+#
+# RELEASE
+#
+FROM alpine
+COPY --from=build-amd64 /libtorrent-build/ /lt-build/amd64/
+COPY --from=build-arm64 /libtorrent-build/ /lt-build/arm64/

--- a/alpine3.22/Dockerfile
+++ b/alpine3.22/Dockerfile
@@ -1,55 +1,15 @@
 FROM alpine:3.22 AS alpine
 
 # 
-# BUILD
-# 
-FROM alpine AS build-base
-
-ARG LT_VER
-
-RUN \
-    echo "**** install build-deps ****" && \
-    apk add --no-cache --update \
-        build-base \
-        `# including file fortify-headers g++ gcc libc-dev make` \
-        openssl-dev \
-        boost-dev \
-        git \
-        cmake \
-        `# python-deps` \
-        boost-python3 py3-setuptools python3-dev
-
-RUN \
-    echo "**** clone source ****" && \
-    GIT_SSL_NO_VERIFY=0 git clone https://github.com/arvidn/libtorrent.git /tmp/libtorrent -b "v${LT_VER}" --depth 1
-
-RUN \
-    echo "**** build libtorrent ****" && \
-    PYTHON_VERSION=$(python3 -c 'import sys; print(".".join(map(str,sys.version_info[:2])))') && \
-    mkdir /tmp/libtorrent/_build -p && \
-    cd /tmp/libtorrent/_build && \
-    cmake \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_INSTALL_PREFIX="/usr" \
-        -DCMAKE_INSTALL_LIBDIR="lib" \
-        -Dpython-bindings=ON \
-        -Dboost-python-module-name="python${PYTHON_VERSION//./}" \
-        "../" && \
-    make VERBOSE=1 -j$(nproc) && \
-    echo "**** install libtorrent ****" && \
-    cd /tmp/libtorrent && \
-    make -C "_build" DESTDIR=/libtorrent-build install && \
-    rm -rf /libtorrent-build/usr/lib/cmake
-
-# 
 # TEST
 # 
 FROM alpine AS test
 
 ARG LT_VER
+ARG TARGETARCH
 
-COPY --from=build-base /libtorrent-build/usr/lib/ /usr/lib/
-COPY --from=build-base /libtorrent-build/usr/lib/ /libtorrent-build/usr/lib/
+COPY build/${TARGETARCH}/usr/ /usr/
+COPY build/${TARGETARCH}/usr/ /libtorrent-build/usr/
 
 RUN \
     echo "**** install runtime packages ****" && \

--- a/alpine3.22/cross-build.dockerfile
+++ b/alpine3.22/cross-build.dockerfile
@@ -1,0 +1,108 @@
+FROM alpine:3.22 AS alpine
+
+#
+# BUILD
+#
+FROM alpine AS build-base
+
+ARG LT_VER
+
+ENV GIT_SSL_NO_VERIFY=0
+
+RUN \
+    echo "**** install build-deps ****" && \
+    apk add --no-cache --update \
+        build-base \
+        openssl-dev \
+        boost-dev \
+        git \
+        cmake \
+        boost-python3 py3-setuptools python3-dev \
+        clang lld apk-tools
+
+RUN \
+    echo "**** clone source ****" && \
+    git clone https://github.com/arvidn/libtorrent.git /tmp/libtorrent -b "v${LT_VER}" --depth 1
+
+#
+# CROSS COMPILE
+#
+FROM build-base AS build-amd64
+
+RUN \
+    echo "**** build libtorrent for amd64 ****" && \
+    PYTHON_VERSION=$(python3 -c 'import sys; print(".".join(map(str,sys.version_info[:2])))') && \
+    mkdir -p /tmp/libtorrent/_build-amd64 && \
+    cd /tmp/libtorrent/_build-amd64 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX="/usr" \
+        -DCMAKE_INSTALL_LIBDIR="lib" \
+        -Dpython-bindings=ON \
+        -Dboost-python-module-name="python${PYTHON_VERSION//./}" \
+        "../" && \
+    make -j$(nproc) && \
+    echo "**** install libtorrent for amd64 ****" && \
+    make DESTDIR=/libtorrent-build install && \
+    rm -rf /libtorrent-build/usr/lib/cmake
+
+FROM build-base AS build-arm64
+
+RUN \
+    echo "**** install arm64 sysroot ****" && \
+    mkdir -p /sysroot/etc/apk && \
+    cp /etc/apk/repositories /sysroot/etc/apk/repositories && \
+    apk --root /sysroot --arch aarch64 --allow-untrusted --initdb add --no-cache \
+        gcc g++ \
+        musl-dev \
+        openssl-dev \
+        boost-dev \
+        boost-python3 \
+        python3-dev \
+        libstdc++ && \
+    echo "**** write cmake toolchain ****" && \
+    { \
+        echo "set(CMAKE_SYSTEM_NAME Linux)"; \
+        echo "set(CMAKE_SYSTEM_PROCESSOR aarch64)"; \
+        echo "set(CMAKE_SYSROOT /sysroot)"; \
+        echo "set(CMAKE_C_COMPILER clang)"; \
+        echo "set(CMAKE_CXX_COMPILER clang++)"; \
+        echo "set(CMAKE_C_COMPILER_TARGET aarch64-alpine-linux-musl)"; \
+        echo "set(CMAKE_CXX_COMPILER_TARGET aarch64-alpine-linux-musl)"; \
+        echo "set(CMAKE_EXE_LINKER_FLAGS_INIT \"-fuse-ld=lld\")"; \
+        echo "set(CMAKE_SHARED_LINKER_FLAGS_INIT \"-fuse-ld=lld\")"; \
+        echo "set(CMAKE_MODULE_LINKER_FLAGS_INIT \"-fuse-ld=lld\")"; \
+        echo "set(CMAKE_FIND_ROOT_PATH /sysroot)"; \
+        echo "set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)"; \
+        echo "set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)"; \
+        echo "set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)"; \
+        echo "set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)"; \
+    } > /tmp/aarch64-alpine-linux-musl.cmake
+
+RUN \
+    echo "**** build libtorrent for arm64 ****" && \
+    PYTHON_VERSION=$(python3 -c 'import sys; print(".".join(map(str,sys.version_info[:2])))') && \
+    mkdir -p /tmp/libtorrent/_build-arm64 && \
+    cd /tmp/libtorrent/_build-arm64 && \
+    cmake \
+        -DCMAKE_TOOLCHAIN_FILE=/tmp/aarch64-alpine-linux-musl.cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX="/usr" \
+        -DCMAKE_INSTALL_LIBDIR="lib" \
+        -Dpython-bindings=ON \
+        -Dboost-python-module-name="python${PYTHON_VERSION//./}" \
+        -DPython3_EXECUTABLE=/usr/bin/python3 \
+        -DPython3_INCLUDE_DIR=/sysroot/usr/include/python${PYTHON_VERSION} \
+        -DPython3_LIBRARY=/sysroot/usr/lib/libpython${PYTHON_VERSION}.so \
+        "../" && \
+    make -j$(nproc) && \
+    echo "**** install libtorrent for arm64 ****" && \
+    make DESTDIR=/libtorrent-build install && \
+    rm -rf /libtorrent-build/usr/lib/cmake
+
+#
+# RELEASE
+#
+FROM alpine
+COPY --from=build-amd64 /libtorrent-build/ /lt-build/amd64/
+COPY --from=build-arm64 /libtorrent-build/ /lt-build/arm64/

--- a/alpine3.23/Dockerfile
+++ b/alpine3.23/Dockerfile
@@ -1,55 +1,15 @@
 FROM alpine:3.23 AS alpine
 
 # 
-# BUILD
-# 
-FROM alpine AS build-base
-
-ARG LT_VER
-
-RUN \
-    echo "**** install build-deps ****" && \
-    apk add --no-cache --update \
-        build-base \
-        `# including file fortify-headers g++ gcc libc-dev make` \
-        openssl-dev \
-        boost-dev \
-        git \
-        cmake \
-        `# python-deps` \
-        boost-python3 py3-setuptools python3-dev
-
-RUN \
-    echo "**** clone source ****" && \
-    GIT_SSL_NO_VERIFY=0 git clone https://github.com/arvidn/libtorrent.git /tmp/libtorrent -b "v${LT_VER}" --depth 1
-
-RUN \
-    echo "**** build libtorrent ****" && \
-    PYTHON_VERSION=$(python3 -c 'import sys; print(".".join(map(str,sys.version_info[:2])))') && \
-    mkdir /tmp/libtorrent/_build -p && \
-    cd /tmp/libtorrent/_build && \
-    cmake \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_INSTALL_PREFIX="/usr" \
-        -DCMAKE_INSTALL_LIBDIR="lib" \
-        -Dpython-bindings=ON \
-        -Dboost-python-module-name="python${PYTHON_VERSION//./}" \
-        "../" && \
-    make VERBOSE=1 -j$(nproc) && \
-    echo "**** install libtorrent ****" && \
-    cd /tmp/libtorrent && \
-    make -C "_build" DESTDIR=/libtorrent-build install && \
-    rm -rf /libtorrent-build/usr/lib/cmake
-
-# 
 # TEST
 # 
 FROM alpine AS test
 
 ARG LT_VER
+ARG TARGETARCH
 
-COPY --from=build-base /libtorrent-build/usr/lib/ /usr/lib/
-COPY --from=build-base /libtorrent-build/usr/lib/ /libtorrent-build/usr/lib/
+COPY build/${TARGETARCH}/usr/ /usr/
+COPY build/${TARGETARCH}/usr/ /libtorrent-build/usr/
 
 RUN \
     echo "**** install runtime packages ****" && \

--- a/alpine3.23/cross-build.dockerfile
+++ b/alpine3.23/cross-build.dockerfile
@@ -1,0 +1,108 @@
+FROM alpine:3.23 AS alpine
+
+#
+# BUILD
+#
+FROM alpine AS build-base
+
+ARG LT_VER
+
+ENV GIT_SSL_NO_VERIFY=0
+
+RUN \
+    echo "**** install build-deps ****" && \
+    apk add --no-cache --update \
+        build-base \
+        openssl-dev \
+        boost-dev \
+        git \
+        cmake \
+        boost-python3 py3-setuptools python3-dev \
+        clang lld apk-tools
+
+RUN \
+    echo "**** clone source ****" && \
+    git clone https://github.com/arvidn/libtorrent.git /tmp/libtorrent -b "v${LT_VER}" --depth 1
+
+#
+# CROSS COMPILE
+#
+FROM build-base AS build-amd64
+
+RUN \
+    echo "**** build libtorrent for amd64 ****" && \
+    PYTHON_VERSION=$(python3 -c 'import sys; print(".".join(map(str,sys.version_info[:2])))') && \
+    mkdir -p /tmp/libtorrent/_build-amd64 && \
+    cd /tmp/libtorrent/_build-amd64 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX="/usr" \
+        -DCMAKE_INSTALL_LIBDIR="lib" \
+        -Dpython-bindings=ON \
+        -Dboost-python-module-name="python${PYTHON_VERSION//./}" \
+        "../" && \
+    make -j$(nproc) && \
+    echo "**** install libtorrent for amd64 ****" && \
+    make DESTDIR=/libtorrent-build install && \
+    rm -rf /libtorrent-build/usr/lib/cmake
+
+FROM build-base AS build-arm64
+
+RUN \
+    echo "**** install arm64 sysroot ****" && \
+    mkdir -p /sysroot/etc/apk && \
+    cp /etc/apk/repositories /sysroot/etc/apk/repositories && \
+    apk --root /sysroot --arch aarch64 --allow-untrusted --initdb add --no-cache \
+        gcc g++ \
+        musl-dev \
+        openssl-dev \
+        boost-dev \
+        boost-python3 \
+        python3-dev \
+        libstdc++ && \
+    echo "**** write cmake toolchain ****" && \
+    { \
+        echo "set(CMAKE_SYSTEM_NAME Linux)"; \
+        echo "set(CMAKE_SYSTEM_PROCESSOR aarch64)"; \
+        echo "set(CMAKE_SYSROOT /sysroot)"; \
+        echo "set(CMAKE_C_COMPILER clang)"; \
+        echo "set(CMAKE_CXX_COMPILER clang++)"; \
+        echo "set(CMAKE_C_COMPILER_TARGET aarch64-alpine-linux-musl)"; \
+        echo "set(CMAKE_CXX_COMPILER_TARGET aarch64-alpine-linux-musl)"; \
+        echo "set(CMAKE_EXE_LINKER_FLAGS_INIT \"-fuse-ld=lld\")"; \
+        echo "set(CMAKE_SHARED_LINKER_FLAGS_INIT \"-fuse-ld=lld\")"; \
+        echo "set(CMAKE_MODULE_LINKER_FLAGS_INIT \"-fuse-ld=lld\")"; \
+        echo "set(CMAKE_FIND_ROOT_PATH /sysroot)"; \
+        echo "set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)"; \
+        echo "set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)"; \
+        echo "set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)"; \
+        echo "set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)"; \
+    } > /tmp/aarch64-alpine-linux-musl.cmake
+
+RUN \
+    echo "**** build libtorrent for arm64 ****" && \
+    PYTHON_VERSION=$(python3 -c 'import sys; print(".".join(map(str,sys.version_info[:2])))') && \
+    mkdir -p /tmp/libtorrent/_build-arm64 && \
+    cd /tmp/libtorrent/_build-arm64 && \
+    cmake \
+        -DCMAKE_TOOLCHAIN_FILE=/tmp/aarch64-alpine-linux-musl.cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX="/usr" \
+        -DCMAKE_INSTALL_LIBDIR="lib" \
+        -Dpython-bindings=ON \
+        -Dboost-python-module-name="python${PYTHON_VERSION//./}" \
+        -DPython3_EXECUTABLE=/usr/bin/python3 \
+        -DPython3_INCLUDE_DIR=/sysroot/usr/include/python${PYTHON_VERSION} \
+        -DPython3_LIBRARY=/sysroot/usr/lib/libpython${PYTHON_VERSION}.so \
+        "../" && \
+    make -j$(nproc) && \
+    echo "**** install libtorrent for arm64 ****" && \
+    make DESTDIR=/libtorrent-build install && \
+    rm -rf /libtorrent-build/usr/lib/cmake
+
+#
+# RELEASE
+#
+FROM alpine
+COPY --from=build-amd64 /libtorrent-build/ /lt-build/amd64/
+COPY --from=build-arm64 /libtorrent-build/ /lt-build/arm64/


### PR DESCRIPTION
## Summary
- Build Alpine amd64 and arm64 artifacts before the final buildx image step.
- Cross-compile Alpine arm64 from the amd64 runner with a clang aarch64 musl toolchain and Alpine arm64 sysroot.
- Let buildx publish Alpine multi-arch manifests directly instead of building arm64 under emulation and assembling manifests in a separate job.

## Validation
- `git diff --check`
- `docker build --build-arg LT_VER=1.2.20 --target build-arm64 -f alpine3.20/cross-build.dockerfile alpine3.20`
- Verified generated Alpine 3.20 arm64 shared objects are `ARM aarch64` ELF files.
- `docker buildx build --platform linux/arm64 --build-arg LT_VER=1.2.20 -f alpine3.20/Dockerfile alpine3.20`
